### PR TITLE
Don't show collection in info panel

### DIFF
--- a/js/src/widgets/metadataView.js
+++ b/js/src/widgets/metadataView.js
@@ -26,7 +26,7 @@
 
       this.metadataTypes.details = _this.getMetadataDetails(_this.manifest);
       this.metadataTypes.rights = _this.getMetadataRights(_this.manifest);
-      this.metadataTypes.links = _this.getMetadataLinks(_this.manifest);
+      // this.metadataTypes.links = _this.getMetadataLinks(_this.manifest);
 
       //vvvvv This is *not* how this should be done.
       jQuery.each(this.metadataTypes, function(metadataKey, metadataValues) {


### PR DESCRIPTION
See https://github.com/jhu-digital-manuscripts/rosa2/issues/298
* Removes the _'within'_ section in the information/metadata panel that links to the parent collection