### PR TITLE
People search changed to exact match

### DIFF
--- a/js/src/widgets/jhAnnotationTab.js
+++ b/js/src/widgets/jhAnnotationTab.js
@@ -122,7 +122,7 @@
 
       var request = {
         service: searchWithin,
-        query: $.generateBasicQuery(term, Array.of(field), '&')
+        query: $.generateBasicQuery('"' + term + '"', Array.of(field), '&')
       };
       this.eventEmitter.publish('REQUEST_SEARCH.' + this.windowId, request);
     },


### PR DESCRIPTION
* Double quotes now surround "people search" from annotation tab so that only exact matches are returned