### PR TITLE
Aor2 pull slot address from save controller

### DIFF
--- a/js/src/utils/saveController.js
+++ b/js/src/utils/saveController.js
@@ -154,6 +154,14 @@
       return returnObject;
     },
 
+    getSlotAddress: function(windowId) {
+      var windowObj = this.getWindowObjectById(windowId);
+      if (windowObj) {
+        return windowObj.slotAddress;
+      }
+      return undefined;
+    },
+
     getWindowAnnotationsList: function(windowId) {
       if (this.windowsAnnotationsLists) {
         return this.windowsAnnotationsLists[windowId];
@@ -291,6 +299,8 @@
         } else {
           windowObjects = [options];
         }
+console.log(' >> Moo change');
+_ = windowObjects;
         _this.set("windowObjects", windowObjects, {parent: "currentConfig"} );
       });
 

--- a/js/src/utils/saveController.js
+++ b/js/src/utils/saveController.js
@@ -299,8 +299,6 @@
         } else {
           windowObjects = [options];
         }
-console.log(' >> Moo change');
-_ = windowObjects;
         _this.set("windowObjects", windowObjects, {parent: "currentConfig"} );
       });
 

--- a/js/src/widgets/jhAnnotationTab.js
+++ b/js/src/widgets/jhAnnotationTab.js
@@ -11,7 +11,6 @@
       visible: false,
       pendingRequests: {},
       eventEmitter: null,
-      slotAddress: null,
       message: {
         error: '<h1 class="error">Failed to load annotation list.</h1>',
         empty: '<h1 class="empty">No annotations available.</h1>',
@@ -181,10 +180,10 @@
      */
     goToPage: function(manifest, page, where) {
       var windowConfig = {
-        'slotAddress': this.slotAddress,
+        'slotAddress': this.state.getSlotAddress(this.windowId),
         'manifest': manifest,
         'canvasID': page,
-        'viewType': this.state.getStateProperty('windowSettings').viewType
+        'viewType': this.state.getWindowObjectById(this.windowId).viewType
       };
 
       if (!where) {

--- a/js/src/widgets/newSearchWidget.js
+++ b/js/src/widgets/newSearchWidget.js
@@ -652,7 +652,7 @@
 
       this.searchResults = new $.SearchResults({
         "parentId": _this.windowId,
-        "slotAddress": _this.slotAddress,
+        "state": _this.state,
         // "currentObject": _this.context.search.object,
         "currentObject": _this.baseObject,
         "appendTo": _this.element.find(".search-results-list"),

--- a/js/src/widgets/searchResults.js
+++ b/js/src/widgets/searchResults.js
@@ -11,7 +11,7 @@
   $.SearchResults = function(options) {
     jQuery.extend(true, this, {
       parentId: null,
-      slotAddress: null,
+      state: null,
       viewer: null,
       hideParent: null,
       appendTo: null,
@@ -111,7 +111,7 @@
 
         // Open search result in currently selected window
         var windowConfig = {
-          "slotAddress": _this.slotAddress,
+          "slotAddress": _this.state.getSlotAddress(_this.parentId),
           "context": _this.context
         };
 

--- a/js/src/widgets/sidePanel.js
+++ b/js/src/widgets/sidePanel.js
@@ -3,7 +3,6 @@
   $.SidePanel= function(options) {
     jQuery.extend(true, this, {
       windowId: null,
-      slotAddress: null,
       pinned: null,
       element:           null,
       appendTo:          null,
@@ -113,8 +112,7 @@
           windowId: _this.windowId,
           canvasID: _this.canvasID,
           eventEmitter: _this.eventEmitter,
-          state: _this.state,
-          slotAddress: _this.slotAddress
+          state: _this.state
         });
       }
       // if (_this.annotationsTabAvailable) {
@@ -146,7 +144,6 @@
           tabId: "searchTab",
           baseObject: this.manifest.jsonLd,
           pinned: this.pinned,
-          slotAddress: this.slotAddress,
           context: this.searchContext,
           state: this.state,
           config: {


### PR DESCRIPTION
Previously, each relevant component would be initialized with a value for `slotAddress` signifying the current slot in which the component lives. When one of these components wants to spawn a new window or modify the current window, it would refer to its `slotAddress` in order for Mirador to mutate the slots arrangement. However, this slot address is not constant - when the window arrangement is modified, the slot address necessarily changes as well. These components were not aware of this change, so any further window operations were failed, because Mirador would not be able to find the "old" slot address.

This change forces components to directly pull the slot address from Mirador's central `saveController` using the window ID, which is always kept up to date.