### PR TITLE
Added border to button's default state

### DIFF
--- a/js/src/jhcomponents/advancedSearchWidget.js
+++ b/js/src/jhcomponents/advancedSearchWidget.js
@@ -397,7 +397,7 @@
             '</div>',
 
             '<div class="input-group-append col-1 p-0">',
-              '<button class="advanced-search-remove btn btn-outline-danger" type="button" aria-label="Remove row">',
+              '<button class="advanced-search-remove btn btn-outline-danger" type="button" aria-label="Remove row" style="border: 1px solid lightgrey;">',
                 '<i class="fa fa-times"></i>',
               '</button>',
             '</div>',


### PR DESCRIPTION
This change adds a border to the default state of the 'close advanced search button' to match the styling near it. Also it just looks better.

Screenshot:
![advanced search with border close btn](https://user-images.githubusercontent.com/4250470/59626901-04a37600-910b-11e9-882d-c946c300ac88.png)
