### PR TITLE
Convert text button to icon button

### DIFF
--- a/js/src/jhcomponents/searchWidget.js
+++ b/js/src/jhcomponents/searchWidget.js
@@ -358,9 +358,10 @@
             '<div class="input-group">',
               '<input class="js-query form-control" type="text" aria-label="Enter search query:" placeholder="Search"/>',
               '<div class="input-group-append">',
-                '<button type="submit" class="btn btn-outline-dark basic-search-submit">',
+                /*'<button type="submit" class="btn btn-outline-dark basic-search-submit">',
                   'Search',
-                '</button>',
+                '</button>',*/
+                '<button class="btn" style="border: 1px solid lightgray;"><i class="fa fa-search"></button>',
               '</div>',
             '</div>',
           '</form>',


### PR DESCRIPTION
Converted the 'search' button to be an icon button rather than text. The reason for doing so is that since there is placeholder text in the text field that says "Search", there is no reason to have the button say the same thing.

Screenshot:
![search icon button](https://user-images.githubusercontent.com/4250470/59633360-5273aa80-911a-11e9-9de5-2f527c2336a2.png)
