### PR TITLE
Issue 430 again, generalizing a workaround

### DIFF
--- a/js/src/history/historyController.js
+++ b/js/src/history/historyController.js
@@ -426,7 +426,7 @@
      */
     handleUrl: function (event) {
       const _this = this;
-
+      
       const url = this.urlSlicer.url(window.location.hash, window.location.search);
       if (!url || url === '') {
         this.triggerCollectionHistory();
@@ -474,6 +474,18 @@
       } else {
         // console.log('%cnon-Evented URL', 'color:brown;');
         const state = this.urlSlicer.parseUrl(url);
+
+        /**
+         * If there is no collection data or the given collection is not known to the viewer
+         * just force the viewer to load the initial collection :(
+         */
+        const knownCollections = this.saveController.getStateProperty('data')
+          .map(entry => entry.collectionUri);
+        if (!state.data.collection || !knownCollections.includes(state.data.collection)) {
+          this.triggerCollectionHistory();
+          return;
+        }
+
         this.addHistory(state);
         this.applyState(state);
       }


### PR DESCRIPTION
Re-addresses issue 430

Generalizes the fix by forcing the viewer to load the "initial collection" when it encounters an unknown collection name in the URL. This should only come up on initial page load, if a user clicks a bad link or manually enters an invalid URL.

This fix will update the history token in the browser.

_initial collection in this context is the collection URL given in the viewer's `index.html`. In our cases it will be either the `aor` collection or `dlmm` collection_